### PR TITLE
Implemented more escape codes for epson printer

### DIFF
--- a/src/preprocessors/EpsonPreprocessor.cc
+++ b/src/preprocessors/EpsonPreprocessor.cc
@@ -87,7 +87,7 @@ void EpsonPreprocessor::process(ICairoTTYProtected &ctty, uint8_t c)
     }
 }
 
-void EpsonPreprocessor::handleEscape(ICairoTTYProtected &ctty, char c)
+void EpsonPreprocessor::handleEscape(ICairoTTYProtected &ctty, uint8_t c)
 {
     // Determine what escape code follows
     if (m_EscapeState == EscapeState::Entered)
@@ -106,8 +106,25 @@ void EpsonPreprocessor::handleEscape(ICairoTTYProtected &ctty, char c)
         case 0x35: // Unset italic
             ctty.SetFontSlant(FontSlant::Normal);
             break;
+        case 0x2a: // '*': Draw Graphics
+            m_GraphicAssembledBytes = 0;
+            m_EscapeState = EscapeState::DrawGraphics;
+            break;
         case 0x2d: // Underline
             m_EscapeState = EscapeState::Underline;
+            break;
+        case 0x33: // '3': Set n/180-inch line spacing
+            m_EscapeState = EscapeState::SetLineSpacing;
+            break;
+        case 0x40: // '@': Initialize
+            // TODO: add init for Cairo here
+            m_InputState = InputState::InputNormal; // Leave escape state
+            break;
+        case 0x44: // 'D': Set horizontal tabs
+            m_EscapeState = EscapeState::SetTabWidth;
+            break;
+        case 0x78: // 'x': Select LQ or draft
+            m_EscapeState = EscapeState::SelectQuality;
             break;
 
         default:
@@ -154,8 +171,75 @@ void EpsonPreprocessor::handleEscape(ICairoTTYProtected &ctty, char c)
         m_InputState = InputState::InputNormal; // Leave escape state
         break;
 
+    case EscapeState::SetLineSpacing:
+        // TODO: implement line spacing in CairoTTY
+        m_InputState = InputState::InputNormal;
+        break;
+
+    case EscapeState::SetTabWidth: // Set width of tabs
+        if (0 == c)
+        {
+            m_InputState = InputState::InputNormal; // Leave escape state
+        }
+        else
+        {
+            // TODO: set tab width for CairoTTY or handle tabs here
+        }
+        break;
+
+    case EscapeState::SelectQuality:
+        // TODO: select quality?
+        m_InputState = InputState::InputNormal;
+        break;
+
+    case EscapeState::DrawGraphics: // Insert tabs in text
+        handleGraphics(ctty, c);
+        break;
+
     default:
         throw std::runtime_error("EpsonPreprocessor::handleEscape(): Internal error: entered unknown escape state "
             + std::to_string(static_cast<int>(m_EscapeState)));
+    }
+}
+
+void EpsonPreprocessor::handleGraphics(ICairoTTYProtected &ctty, uint8_t c)
+{
+    static int col;
+
+    if (0 == m_GraphicAssembledBytes)
+    {
+        m_GraphicsMode = c;
+        m_GraphicAssembledBytes = 1;
+    }
+    else if (m_GraphicAssembledBytes == 1)
+    {
+        m_GraphicsNrColumns = (unsigned char) c;
+        m_GraphicAssembledBytes = 2;
+    }
+    else if (m_GraphicAssembledBytes == 2)
+    {
+        int nh = (unsigned char) c;
+        m_GraphicsNrColumns += nh * 256;
+        m_GraphicAssembledBytes = 3;
+    }
+    else
+    {
+        if (m_GraphicAssembledBytes == 3)
+        {
+            m_GraphicsMaxBytes = m_GraphicsNrColumns * 3;
+        }
+
+        int rowGroup = m_GraphicAssembledBytes % 3;
+        col |= ((unsigned int) c) << (8 * (2 - rowGroup));
+        if (2 == rowGroup)
+        {
+            col = 0;
+        }
+
+        ++m_GraphicAssembledBytes;
+        if (m_GraphicAssembledBytes >= (m_GraphicsMaxBytes + 3))
+        {
+            m_InputState = InputState::InputNormal; // Leave escape state
+        }
     }
 }

--- a/src/preprocessors/EpsonPreprocessor.h
+++ b/src/preprocessors/EpsonPreprocessor.h
@@ -29,7 +29,8 @@ public:
     virtual void process(ICairoTTYProtected &ctty, uint8_t c) override;
 
 private:
-    void handleEscape(ICairoTTYProtected &ctty, char c);
+    void handleEscape(ICairoTTYProtected &ctty, uint8_t c);
+    void handleGraphics(ICairoTTYProtected &ctty, uint8_t c);
 
     enum class InputState
     {
@@ -40,7 +41,12 @@ private:
     enum class EscapeState
     {
         Entered,
-        Underline
+        Underline,
+        SetLineSpacing,
+        SetTabWidth,
+        SelectQuality,
+        DrawGraphics,
+        Unknown
     };
 
     enum class FontSizeState
@@ -54,6 +60,12 @@ private:
     EscapeState m_EscapeState;
     FontSizeState m_FontSizeState;
     bool m_Escape;
+    int m_GraphicAssembledBytes;
+    uint8_t m_GraphicsMode; // Graphics mode
+    int m_GraphicsDpi; // Dots per inch
+    int m_GraphicsDpc; // Dots per column
+    int m_GraphicsNrColumns; // Number of columns
+    int m_GraphicsMaxBytes; // Number of columns
 };
 
 #endif // EPSON_PREPROCESSOR_H_


### PR DESCRIPTION
Codes are not evaluated but just dropped from the output file.
I made this PR first which will enable dotprint to drop the escaped sequence for graphics printing. I already have an approach how to parse the payload but i don't know how to print these bitmaps with cairo. I implemented some handling with much of magic numbers and printing of lines in cairo. But there must be a much better solution for this.