### PR TITLE
Fixed single character options

### DIFF
--- a/src/CmdLineParser.cc
+++ b/src/CmdLineParser.cc
@@ -44,7 +44,7 @@ const struct option CmdLineParser::LONG_OPTIONS[] =
     { 0, 0, 0, 0 }
 };
 
-const char *CmdLineParser::SHORT_OPTIONS="p:lo:P:t:m:h";
+const char *CmdLineParser::SHORT_OPTIONS="p:lo:P:t:f:s:m:h";
 
 const char *CmdLineParser::DEFAULT_FONT_FACE = "Courier New";
 const double CmdLineParser::DEFAULT_FONT_SIZE = 11.0;


### PR DESCRIPTION
Some options listed in the help text were not evaluated correctly.

I just experienced that the short option -s could not be used so i found this problem