### PR TITLE
Add docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:latest as stage
+
+RUN apk update && \
+    apk add glibmm-dev cairomm-dev gcc g++ cmake make
+
+COPY . /build
+
+WORKDIR /build
+
+RUN cmake . && make
+
+FROM alpine:latest
+LABEL MAINTAINER="github/@rusq"
+
+RUN apk update
+RUN apk add libstdc++ cairomm glibmm msttcorefonts-installer
+
+RUN update-ms-fonts && fc-cache -f
+
+COPY --from=stage /build/src/dotprint /bin/dotprint
+
+WORKDIR /work
+
+ENTRYPOINT [ "/bin/dotprint" ]
+CMD [ "--help" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM alpine:latest as stage
+FROM alpine:3.11 as stage
 
-RUN apk update && \
-    apk add glibmm-dev cairomm-dev gcc g++ cmake make
+RUN apk --no-cache add glibmm-dev cairomm-dev gcc g++ cmake make
 
 COPY . /build
 
@@ -9,11 +8,10 @@ WORKDIR /build
 
 RUN cmake . && make
 
-FROM alpine:latest
+FROM alpine:3.11
 LABEL MAINTAINER="github/@rusq"
 
-RUN apk update
-RUN apk add libstdc++ cairomm glibmm msttcorefonts-installer
+RUN apk --no-cache add libstdc++ cairomm glibmm msttcorefonts-installer
 
 RUN update-ms-fonts && fc-cache -f
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can specify your own `DESTDIR`.
 
 # Usage
 
-You need to specifiy:
+You need to specify:
 
 * the input file (text input with potential escape sequences, in UTF-8 encoding)
 * the output file (PDF)
@@ -53,6 +53,37 @@ You most likely want to specify the preprocessor. By default only newlines are i
     dotprint input-file.txt -o output-file.pdf -P epson
 
 Run `dotprint -h` for a list of all the options.
+
+# Building Docker Container
+
+This might be useful if you're using macOS and don't have development tools or
+C++ compiler, but have Docker.
+
+To build the docker container, run:
+
+    ./build-docker.sh
+
+This will build `dotprint:latest` image based on `alpine:latest` with some
+preinstalled font (including the Courier New, which is used by default).
+
+# Running in Docker
+
+
+
+The easy way to run conversion is:
+
+    ./convert.sh input.prn -o output.pdf
+
+Docker container has `dotprint` as an entry point and any options specified on
+the command line are the commands are passed to the dotprint executable.
+
+If you need to run this manually, you'd need to volume-mount the current
+directory to `/work` directory of the container, i.e.:
+
+    docker run --rm -v `pwd`:/work dotprint \
+        -P epson \
+        tests/test4.ASCII.prn \
+        -o output.pdf
 
 # Licence
 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build . -t dotprint:latest

--- a/convert.sh
+++ b/convert.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 CONTAINER_NAME=dotprint
-workdir=`pwd`
-docker run --rm -v "${workdir}":/work ${CONTAINER_NAME} $*
+docker run --rm -v "$(pwd)":/work ${CONTAINER_NAME} $*

--- a/convert.sh
+++ b/convert.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+CONTAINER_NAME=dotprint
+workdir=`pwd`
+docker run --rm -v "${workdir}":/work ${CONTAINER_NAME} $*


### PR DESCRIPTION
Hey David,

This idea has been following me since the first day I say your repository, because I wanted to try dotprint, but was unable to build it on my mac natively.

I based the build on alpine linux, seems to work great, also chuck in some fonts, so Courier New is available out of the box.

Updated readme to reflect the changes.

Suggestions/comments are welcome.

Rustam